### PR TITLE
removing progress bars while training

### DIFF
--- a/tasks/fine_tuning_sbert/src/loops.py
+++ b/tasks/fine_tuning_sbert/src/loops.py
@@ -128,6 +128,7 @@ def grid_search_fine_tune_sbert(train_params, train_sents, train_labels, label_n
                           model_deets=model_deets,
                           baseline=baseline,
                           patience=patience,
+                          show_progress_bar=False
                           )
 
                 end = time.time()


### PR DESCRIPTION
Removing the progress bar while training as that may take up RAM space on colab.